### PR TITLE
Add unit tests for lucky.py and GitHub Actions CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run tests
+        run: uv run pytest tests/ -v

--- a/cases/webs/lucky.py
+++ b/cases/webs/lucky.py
@@ -13,11 +13,11 @@ from urllib.parse import quote_plus
 from googlesearch import search
 
 
-def main():
+def main(argv=None):
     parser = argparse.ArgumentParser(description="Open the top Google results for a search")
     parser.add_argument("-n", type=int, default=4, dest="count", help="number of result pages to open (default: 4)")
     parser.add_argument("query", nargs="+", help="search terms")
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     query = " ".join(args.query)
     print(f"Googling '{query}'...")

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,8 @@ yt = "scripts.webs.youtube:main"
 [tool.setuptools]
 packages = []  # Tells it not to look for library packages
 py-modules = [] # Tells it not to look for top-level modules
+
+[dependency-groups]
+dev = [
+    "pytest>=9.1.1",
+]

--- a/tests/test_lucky.py
+++ b/tests/test_lucky.py
@@ -1,0 +1,74 @@
+import pytest
+
+from cases.webs import lucky
+
+
+def test_no_query_exits_with_usage_error():
+    with pytest.raises(SystemExit) as exc_info:
+        lucky.main([])
+    assert exc_info.value.code == 2
+
+
+def test_default_count_is_four(monkeypatch):
+    seen = {}
+
+    def fake_search(term, num_results):
+        seen["term"] = term
+        seen["num_results"] = num_results
+        return ["https://example.com/a", "https://example.com/b"]
+
+    monkeypatch.setattr(lucky, "search", fake_search)
+    opened = []
+    monkeypatch.setattr(lucky.webbrowser, "open", lambda url: opened.append(url))
+
+    lucky.main(["tips", "for", "developers"])
+
+    assert seen == {"term": "tips for developers", "num_results": 4}
+    assert opened == ["https://example.com/a", "https://example.com/b"]
+
+
+def test_n_flag_sets_result_count(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(
+        lucky, "search",
+        lambda term, num_results: seen.setdefault("num_results", num_results) or [],
+    )
+    monkeypatch.setattr(lucky.webbrowser, "open", lambda url: None)
+
+    lucky.main(["-n3", "python", "requests"])
+
+    assert seen["num_results"] == 3
+
+
+def test_opens_each_scraped_result(monkeypatch):
+    urls = ["https://a.example", "https://b.example", "https://c.example"]
+    monkeypatch.setattr(lucky, "search", lambda term, num_results: urls)
+    opened = []
+    monkeypatch.setattr(lucky.webbrowser, "open", lambda url: opened.append(url))
+
+    lucky.main(["some", "query"])
+
+    assert opened == urls
+
+
+def test_falls_back_to_search_page_when_no_results(monkeypatch):
+    monkeypatch.setattr(lucky, "search", lambda term, num_results: [])
+    opened = []
+    monkeypatch.setattr(lucky.webbrowser, "open", lambda url: opened.append(url))
+
+    lucky.main(["python", "requests", "library"])
+
+    assert opened == ["https://www.google.com/search?q=python+requests+library"]
+
+
+def test_falls_back_to_search_page_when_scraping_raises(monkeypatch):
+    def raise_error(term, num_results):
+        raise RuntimeError("blocked")
+
+    monkeypatch.setattr(lucky, "search", raise_error)
+    opened = []
+    monkeypatch.setattr(lucky.webbrowser, "open", lambda url: opened.append(url))
+
+    lucky.main(["weird & special?", "chars"])
+
+    assert opened == ["https://www.google.com/search?q=weird+%26+special%3F+chars"]

--- a/uv.lock
+++ b/uv.lock
@@ -27,6 +27,11 @@ dependencies = [
     { name = "yt-dlp" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "googlesearch-python", specifier = ">=1.3.0" },
@@ -35,6 +40,9 @@ requires-dist = [
     { name = "quickjs", specifier = ">=1.19.4" },
     { name = "yt-dlp", extras = ["build-in-js-interpreter", "javascript"], specifier = ">=2026.3.17" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.1.1" }]
 
 [[package]]
 name = "certifi"
@@ -177,6 +185,15 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
 name = "et-xmlfile"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -208,6 +225,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "openpyxl"
 version = "3.1.5"
 source = { registry = "https://pypi.org/simple" }
@@ -217,6 +243,49 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- `lucky.main()` now takes an optional `argv` so tests can call it directly
- 6 pytest tests covering usage errors, `-n` flag, result-opening, and both fallback paths — network call and `webbrowser.open` are mocked, so tests run in <1s with no real requests
- `.github/workflows/tests.yml` runs the suite on every PR and push to master via GitHub Actions

## Cost
Repo is public, so GitHub Actions is free (unlimited minutes).

## Test plan
- [x] `uv run pytest tests/ -v` — 6/6 passed locally
- [ ] Confirm the Actions tab shows the workflow running green on this PR