### PR TITLE
Avoid filename collisions in clipsave

### DIFF
--- a/tests/test_clipsave.py
+++ b/tests/test_clipsave.py
@@ -106,3 +106,51 @@ def test_skips_missing_paths_and_falls_back_when_nothing_saved(monkeypatch, isol
         clipsave.main()
 
     assert list(isolated_downloads.iterdir()) == []
+
+
+def test_text_runs_at_the_same_timestamp_dont_overwrite_each_other(monkeypatch, isolated_downloads):
+    monkeypatch.setattr(clipsave.ImageGrab, "grabclipboard", lambda: None)
+    monkeypatch.setattr(clipsave, "get_clipboard_text", lambda: "first run")
+    clipsave.main()
+
+    monkeypatch.setattr(clipsave, "get_clipboard_text", lambda: "second run")
+    clipsave.main()
+
+    first = isolated_downloads / "2026-08-28 09-45-50.txt"
+    second = isolated_downloads / "2026-08-28 09-45-50 (1).txt"
+    assert first.read_text(encoding="utf-8") == "first run"
+    assert second.read_text(encoding="utf-8") == "second run"
+
+
+def test_image_runs_at_the_same_timestamp_dont_overwrite_each_other(monkeypatch, isolated_downloads):
+    monkeypatch.setattr(clipsave.ImageGrab, "grabclipboard", lambda: Image.new("RGB", (5, 5), color="red"))
+    clipsave.main()
+    clipsave.main()
+
+    assert (isolated_downloads / "2026-08-28 09-45-50.png").exists()
+    assert (isolated_downloads / "2026-08-28 09-45-50 (1).png").exists()
+
+
+def test_copied_file_runs_at_the_same_timestamp_dont_overwrite_each_other(tmp_path, monkeypatch, isolated_downloads):
+    source = tmp_path / "notes.txt"
+    source.write_text("original content", encoding="utf-8")
+    monkeypatch.setattr(clipsave.ImageGrab, "grabclipboard", lambda: [str(source)])
+
+    clipsave.main()
+    clipsave.main()
+
+    assert (isolated_downloads / "2026-08-28 09-45-50 notes.txt").exists()
+    assert (isolated_downloads / "2026-08-28 09-45-50 notes (1).txt").exists()
+
+
+def test_zipped_folder_runs_at_the_same_timestamp_dont_overwrite_each_other(tmp_path, monkeypatch, isolated_downloads):
+    folder = tmp_path / "project"
+    folder.mkdir()
+    (folder / "a.txt").write_text("a", encoding="utf-8")
+    monkeypatch.setattr(clipsave.ImageGrab, "grabclipboard", lambda: [str(folder)])
+
+    clipsave.main()
+    clipsave.main()
+
+    assert (isolated_downloads / "2026-08-28 09-45-50 project.zip").exists()
+    assert (isolated_downloads / "2026-08-28 09-45-50 project (1).zip").exists()

--- a/wins/clipsave.py
+++ b/wins/clipsave.py
@@ -21,6 +21,17 @@ def report_saved(action, path):
     print(f"Folder: {path.parent}")
 
 
+def unique_path(path):
+    if not path.exists():
+        return path
+    n = 1
+    while True:
+        candidate = path.with_name(f"{path.stem} ({n}){path.suffix}")
+        if not candidate.exists():
+            return candidate
+        n += 1
+
+
 def get_clipboard_text():
     import tkinter as tk
 
@@ -43,11 +54,12 @@ def save_clipboard_files(paths, downloads, timestamp):
             continue
 
         if source.is_dir():
-            archive_base = downloads / f"{timestamp} {source.name}"
+            target_zip = unique_path(downloads / f"{timestamp} {source.name}.zip")
+            archive_base = target_zip.with_suffix("")
             archive_path = Path(shutil.make_archive(str(archive_base), "zip", root_dir=source.parent, base_dir=source.name))
             report_saved("Zipped folder", archive_path)
         else:
-            dest = downloads / f"{timestamp} {source.name}"
+            dest = unique_path(downloads / f"{timestamp} {source.name}")
             shutil.copy2(source, dest)
             report_saved("Copied file", dest)
         saved_any = True
@@ -63,7 +75,7 @@ def main():
     clip_content = ImageGrab.grabclipboard()
 
     if isinstance(clip_content, Image.Image):
-        path = downloads / f"{timestamp}.png"
+        path = unique_path(downloads / f"{timestamp}.png")
         clip_content.save(path)
         report_saved("Saved image", path)
         return
@@ -74,7 +86,7 @@ def main():
 
     text = get_clipboard_text()
     if text:
-        path = downloads / f"{timestamp}.txt"
+        path = unique_path(downloads / f"{timestamp}.txt")
         path.write_text(text, encoding="utf-8")
         report_saved("Saved text", path)
         return


### PR DESCRIPTION
## Summary
- Two `clipsave` runs within the same second previously overwrote each other silently (timestamp is second-precision)
- Added `unique_path(): appends "(1)", "(2)", ... before the extension if the target already exists, applied to all four save sites

## Test plan
- [x] Ran clipsave twice in immediate succession against the real clipboard — got two distinct files with distinct content, no overwrite
- [x] 4 new mocked tests (one per save type), 17/17 total tests passing