### PR TITLE
Add pinned taskbar icon for clipsave/b64d/b64e

### DIFF
--- a/devs/taskbar/run_b64d.bat
+++ b/devs/taskbar/run_b64d.bat
@@ -1,0 +1,6 @@
+@echo off
+title Boring - b64d
+"%~dp0..\..\.venv\Scripts\b64d.exe"
+echo.
+echo Closing in 60 seconds - press any key to close now.
+timeout /t 60

--- a/devs/taskbar/run_b64e.bat
+++ b/devs/taskbar/run_b64e.bat
@@ -1,0 +1,6 @@
+@echo off
+title Boring - b64e
+"%~dp0..\..\.venv\Scripts\b64e.exe"
+echo.
+echo Closing in 60 seconds - press any key to close now.
+timeout /t 60

--- a/devs/taskbar/run_clipsave.bat
+++ b/devs/taskbar/run_clipsave.bat
@@ -1,0 +1,6 @@
+@echo off
+title Boring - clipsave
+"%~dp0..\..\.venv\Scripts\clipsave.exe"
+echo.
+echo Closing in 60 seconds - press any key to close now.
+timeout /t 60

--- a/devs/taskbar/setup_taskbar_icon.py
+++ b/devs/taskbar/setup_taskbar_icon.py
@@ -1,0 +1,107 @@
+#! python3
+# One-time setup for a "Boring" taskbar shortcut:
+#   - generates a B-lettered icon
+#   - creates Boring.lnk, whose default target runs clipsave
+#   - registers a Jump List (right-click menu) with b64d/b64e tasks
+#
+# Run: uv run python devs/taskbar/setup_taskbar_icon.py
+# Then: open the folder it prints, right-click Boring.lnk, "Pin to taskbar".
+# Safe to re-run any time to refresh the icon or the Jump List tasks.
+
+import os
+from pathlib import Path
+
+import pythoncom
+import win32com.propsys.propsys as propsys
+import win32com.propsys.pscon as pscon
+import win32com.shell.shell as shell
+import win32com.shell.shellcon as shellcon
+from PIL import Image, ImageDraw, ImageFont
+
+APP_ID = "BoringStuff.Launcher"
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+TASKBAR_DIR = Path(__file__).resolve().parent
+DATA_DIR = Path.home() / ".boring-stuff"
+ICON_PATH = DATA_DIR / "boring.ico"
+SHORTCUT_PATH = DATA_DIR / "Boring.lnk"
+CMD_EXE = r"C:\Windows\System32\cmd.exe"
+
+# (display title in the Jump List, .bat file to run)
+TASKS = [
+    ("Decode base64 (b64d)", "run_b64d.bat"),
+    ("Encode base64 (b64e)", "run_b64e.bat"),
+]
+
+
+def generate_icon():
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    font = None
+    for name in ("arialbd.ttf", "segoeuib.ttf", "calibrib.ttf"):
+        path = os.path.join(os.environ["WINDIR"], "Fonts", name)
+        if os.path.exists(path):
+            font = ImageFont.truetype(path, 190)
+            break
+    if font is None:
+        font = ImageFont.load_default()
+
+    size = 256
+    img = Image.new("RGBA", (size, size), (25, 25, 25, 255))
+    draw = ImageDraw.Draw(img)
+    bbox = draw.textbbox((0, 0), "B", font=font)
+    w, h = bbox[2] - bbox[0], bbox[3] - bbox[1]
+    draw.text(((size - w) / 2 - bbox[0], (size - h) / 2 - bbox[1]), "B", font=font, fill=(240, 200, 60, 255))
+    img.save(ICON_PATH, sizes=[(16, 16), (32, 32), (48, 48), (256, 256)])
+
+
+def make_link(bat_name):
+    link = pythoncom.CoCreateInstance(shell.CLSID_ShellLink, None, pythoncom.CLSCTX_INPROC_SERVER, shell.IID_IShellLinkW)
+    link.SetPath(CMD_EXE)
+    link.SetArguments(f'/c "{TASKBAR_DIR / bat_name}"')
+    link.SetIconLocation(str(ICON_PATH), 0)
+    link.SetWorkingDirectory(str(REPO_ROOT))
+    return link
+
+
+def set_title(link, title):
+    store = link.QueryInterface(propsys.IID_IPropertyStore)
+    store.SetValue(pscon.PKEY_Title, propsys.PROPVARIANTType(title))
+    store.Commit()
+
+
+def create_main_shortcut():
+    link = make_link("run_clipsave.bat")
+    link.SetDescription("Boring - clipsave")
+    persist = link.QueryInterface(pythoncom.IID_IPersistFile)
+    persist.Save(str(SHORTCUT_PATH), True)
+
+    store = propsys.SHGetPropertyStoreFromParsingName(str(SHORTCUT_PATH), None, shellcon.GPS_READWRITE, propsys.IID_IPropertyStore)
+    store.SetValue(pscon.PKEY_AppUserModel_ID, propsys.PROPVARIANTType(APP_ID))
+    store.Commit()
+
+
+def register_jump_list():
+    collection = pythoncom.CoCreateInstance(shell.CLSID_EnumerableObjectCollection, None, pythoncom.CLSCTX_INPROC_SERVER, shell.IID_IObjectCollection)
+    for title, bat_name in TASKS:
+        task_link = make_link(bat_name)
+        set_title(task_link, title)
+        collection.AddObject(task_link)
+
+    dest_list = pythoncom.CoCreateInstance(shell.CLSID_DestinationList, None, pythoncom.CLSCTX_INPROC_SERVER, shell.IID_ICustomDestinationList)
+    dest_list.SetAppID(APP_ID)
+    dest_list.BeginList()
+    dest_list.AddUserTasks(collection.QueryInterface(shell.IID_IObjectArray))
+    dest_list.CommitList()
+
+
+def main():
+    generate_icon()
+    create_main_shortcut()
+    register_jump_list()
+
+    print(f"Shortcut created: {SHORTCUT_PATH}")
+    print("Right-click it in Explorer and choose 'Pin to taskbar' to finish setup.")
+    print("Left-click on the pinned icon runs clipsave; right-click shows the b64d/b64e menu.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "googlesearch-python>=1.3.0",
     "pillow>=12.3.0",
     "pyperclip>=1.11.0",
+    "pywin32>=312; sys_platform == 'win32'",
 ]
 
 [project.scripts]
@@ -23,6 +24,9 @@ b64e = "devs.base64_clip:main_encode"
 [tool.setuptools]
 packages = []  # Tells it not to look for library packages
 py-modules = [] # Tells it not to look for top-level modules
+
+[tool.uv]
+package = true
 
 [dependency-groups]
 dev = [

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -85,3 +85,16 @@ Run command:
 
 If the clipboard isn't valid base64 (for `b64d`), or is empty, prints a
 message and exits non-zero without touching the clipboard.
+
+## Boring taskbar icon
+A pinned taskbar shortcut ("B" icon): left-click runs `clipsave`, right-click
+shows a Jump List menu with `b64d`/`b64e`. Each opens a terminal window that
+shows the result and closes itself after 60 seconds (or on any keypress).
+
+One-time setup:
+
+    uv run python devs/taskbar/setup_taskbar_icon.py
+
+Then, in the folder it prints (`%USERPROFILE%\.boring-stuff`), right-click
+`Boring.lnk` and choose "Pin to taskbar". Safe to re-run the setup script any
+time - it refreshes the icon and the Jump List tasks in place.

--- a/uv.lock
+++ b/uv.lock
@@ -18,12 +18,13 @@ wheels = [
 [[package]]
 name = "boring-stuff"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "googlesearch-python" },
     { name = "openpyxl" },
     { name = "pillow" },
     { name = "pyperclip" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "pyyaml" },
     { name = "quickjs" },
     { name = "yt-dlp" },
@@ -40,6 +41,7 @@ requires-dist = [
     { name = "openpyxl" },
     { name = "pillow", specifier = ">=12.3.0" },
     { name = "pyperclip", specifier = ">=1.11.0" },
+    { name = "pywin32", marker = "sys_platform == 'win32'", specifier = ">=312" },
     { name = "pyyaml" },
     { name = "quickjs", specifier = ">=1.19.4" },
     { name = "yt-dlp", extras = ["build-in-js-interpreter", "javascript"], specifier = ">=2026.3.17" },
@@ -370,6 +372,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
One-time setup script creates a 'B' taskbar shortcut: left-click runs clipsave, right-click shows a Jump List with b64d/b64e. Also fixes a recurring bug where plain 'uv sync' was silently uninstalling this project's own console scripts (added tool.uv.package = true). pywin32 added as a Windows-only dependency (sys_platform marker) so CI on ubuntu-latest is unaffected. Can't verify the actual taskbar UI from here - needs manual pin + right-click check.