### PR TITLE
Restructure scripts/README.md into a manual

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,13 +1,28 @@
-# Available scripts
+# Boring stuff - manual
 
-## Hello
-Run command:
+Boring Stuff is a personal collection of small command-line utilities that
+take care of repetitive, everyday tasks - clipboard conversions, quick web
+lookups, image tweaks, downloads, and more - so you don't have to do them by
+hand every time.
 
-    hello
+## Add Boring Stuff to Taskbar in windows
+A pinned taskbar shortcut ("B" icon): left-click runs `clipsave`, right-click
+shows a Jump List menu with `b64d`/`b64e`. Each opens a terminal window that
+shows the result and closes itself after 60 seconds (or on any keypress).
 
-to ensure that scrips can be run from CMD. 
-## Lucky
+One-time setup:
 
+    uv run python devs/taskbar/setup_taskbar_icon.py
+
+Then, in the folder it prints (`%USERPROFILE%\.boring-stuff`), right-click
+`Boring.lnk` and choose "Pin to taskbar". Safe to re-run the setup script any
+time - it refreshes the icon and the Jump List tasks in place.
+
+## Available scripts
+
+### cases
+
+#### Lucky
 Open several (default is 4) page in default browser from googling
 
 Run command:
@@ -19,7 +34,7 @@ Parameters:
 
 **-n3** - number of pages opened in browser
 
-## Mapit
+#### Mapit
 Open google map with specific address:
 - default is taken from clipboard
 - from argument of the command
@@ -29,19 +44,48 @@ Run command:
     mapit  (takes address from clipboard)
     mapit Bratislava
 
-## Pinterest
+#### Negative
+Invert picture in negative colors.
+Run command:
+
+    negative [directory_with_picture]
+
+#### Pinterest
 Open random picture from pinteres board
 
 Run command:
 
     pinterest
-    
+
 Configuration (in userHome/BoringStuff.ini):
 
     [Pinterest]
     RandomBoard: https://pinterest.com/username/board.rss
-    
-## Youtube
+
+### devs
+
+#### B64d / B64e
+Base64 decode/encode the clipboard's text, in place - result goes straight
+back onto the clipboard, no files, no arguments.
+
+Run command:
+
+    b64d   (decode)
+    b64e   (encode)
+
+If the clipboard isn't valid base64 (for `b64d`), or is empty, prints a
+message and exits non-zero without touching the clipboard.
+
+### scripts
+
+#### Hello
+Run command:
+
+    hello
+
+to ensure that scrips can be run from CMD.
+
+#### Youtube
 Download youtube video.
 Run command:
 
@@ -49,14 +93,9 @@ Run command:
     youtube [youtube url]
     youtube [youtube playlist url]
 
+### wins
 
-## Negative
-Invert picture in negative colors.
-Run command:
-
-    negative [directory_with_picture]
-
-## Clipsave
+#### Clipsave
 Save clipboard content to your Downloads folder. Auto-detects the content
 type - no prompt, no flags needed:
 
@@ -73,28 +112,3 @@ Run command:
 Timestamp format is `YYYY-MM-dd HH-mm-ss` (e.g. `2026-08-28 09-45-50`).
 Prints a message and exits non-zero if the clipboard is empty or nothing
 could be saved.
-
-## B64d / B64e
-Base64 decode/encode the clipboard's text, in place - result goes straight
-back onto the clipboard, no files, no arguments.
-
-Run command:
-
-    b64d   (decode)
-    b64e   (encode)
-
-If the clipboard isn't valid base64 (for `b64d`), or is empty, prints a
-message and exits non-zero without touching the clipboard.
-
-## Boring taskbar icon
-A pinned taskbar shortcut ("B" icon): left-click runs `clipsave`, right-click
-shows a Jump List menu with `b64d`/`b64e`. Each opens a terminal window that
-shows the result and closes itself after 60 seconds (or on any keypress).
-
-One-time setup:
-
-    uv run python devs/taskbar/setup_taskbar_icon.py
-
-Then, in the folder it prints (`%USERPROFILE%\.boring-stuff`), right-click
-`Boring.lnk` and choose "Pin to taskbar". Safe to re-run the setup script any
-time - it refreshes the icon and the Jump List tasks in place.


### PR DESCRIPTION
Retitles the doc to 'Boring stuff - manual' with a short intro, moves the taskbar setup ('Add Boring Stuff to Taskbar in windows') up as its own section ahead of the reference, and groups the remaining commands under 'Available scripts' by the repo folder they live in (cases, devs, scripts, wins), alphabetical within each folder.