### PR TITLE
Give lucky/mapit/negative/pinterest/openwebs/mp4to3 working bare commands

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,7 +17,6 @@ Running list of things discussed but not yet done. Remove an item once it's buil
 ## Known bugs/gaps
 
 - `clean-logs` console script in `pyproject.toml` points to `scripts.cleanup:run`, which doesn't exist - crashes if run
-- `lucky`, `mapit`, `negative`, `pinterest`, `openwebs`, `mp4to3` have no working bare command - they only run via `.bat` shims that depend on `BORING_STUFF_PATH`, which is unset on this machine (workaround: `uv run cases/webs/<script>.py`)
 - `scripts/hello.py` throws `UnicodeEncodeError` on this console's codepage (emoji in a `print`)
 - `mapit.py`/`negative.py` lack basic error handling (empty clipboard, non-image files in a directory)
 

--- a/cases/maps/mapit.py
+++ b/cases/maps/mapit.py
@@ -7,11 +7,17 @@ import webbrowser
 import sys
 import tkinter as tk
 
-if len(sys.argv) > 1:
-    # Get address from command line.
-    address = ' '.join(sys.argv[1:])
-else:
-    root = tk.Tk()
-    address = root.clipboard_get()
 
-webbrowser.open('https://www.google.com/maps/place/' + address)
+def main():
+    if len(sys.argv) > 1:
+        # Get address from command line.
+        address = ' '.join(sys.argv[1:])
+    else:
+        root = tk.Tk()
+        address = root.clipboard_get()
+
+    webbrowser.open('https://www.google.com/maps/place/' + address)
+
+
+if __name__ == "__main__":
+    main()

--- a/cases/pictures/negative.py
+++ b/cases/pictures/negative.py
@@ -6,16 +6,22 @@ from PIL import Image, ImageOps
 import sys
 import os
 
-if len(sys.argv) > 1:
-    # Get directory from command line.
-    directory = ' '.join(sys.argv[1:])
 
-    for x in os.listdir(directory):
-        im = Image.open(directory + '/' + x)
-        im_invert = ImageOps.invert(im)
-        im_invert.save(directory + '/negative' + x )
-        print("Picture " + x + " was changed to negative")
+def main():
+    if len(sys.argv) > 1:
+        # Get directory from command line.
+        directory = ' '.join(sys.argv[1:])
 
-else:
-    print("No parameter was inserted.")
+        for x in os.listdir(directory):
+            im = Image.open(directory + '/' + x)
+            im_invert = ImageOps.invert(im)
+            im_invert.save(directory + '/negative' + x )
+            print("Picture " + x + " was changed to negative")
+
+    else:
+        print("No parameter was inserted.")
+
+
+if __name__ == "__main__":
+    main()
 

--- a/cases/webs/mp4to3.py
+++ b/cases/webs/mp4to3.py
@@ -45,13 +45,13 @@ def main():
     format = 'mp4'
 
     path_with_album = url_to_convert
-    source_dir = Path(path_with_album + '\\')
+    source_dir = Path(path_with_album)
     files = source_dir.glob('*.mp4')
     for file in files:
         print(file.name)
         filename = file.name.replace('.mp4', '.mp3')
-        audioDir = path_with_album + ' - audio\\'
-        extract_audio(input_path=file, output_path=audioDir + filename)
+        audioDir = Path(path_with_album + ' - audio')
+        extract_audio(input_path=file, output_path=str(audioDir / filename))
 
 
 if __name__ == "__main__":

--- a/cases/webs/mp4to3.py
+++ b/cases/webs/mp4to3.py
@@ -14,40 +14,45 @@ from pathlib import Path
 import yt_dlp as youtube_dl
 from audio_extract import extract_audio
 
-# Compatibility fixes for Windows
-if sys.platform == 'win32':
-  # https://github.com/ytdl-org/youtube-dl/issues/820
-  codecs.register(
-    lambda name: codecs.lookup('utf-8') if name == 'cp65001' else None)
+def main():
+    # Compatibility fixes for Windows
+    if sys.platform == 'win32':
+      # https://github.com/ytdl-org/youtube-dl/issues/820
+      codecs.register(
+        lambda name: codecs.lookup('utf-8') if name == 'cp65001' else None)
 
-home = str(pathlib.Path.home())
+    home = str(pathlib.Path.home())
 
-# read an options and ur
-argIndex = 1
-alsoAudioFile = True
+    # read an options and ur
+    argIndex = 1
+    alsoAudioFile = True
 
-joined = ' '.join(sys.argv)
-fromIndex = joined.find(' ') +1
-url_to_convert = joined[fromIndex:]
+    joined = ' '.join(sys.argv)
+    fromIndex = joined.find(' ') +1
+    url_to_convert = joined[fromIndex:]
 
-print("<<<" + url_to_convert + ">>>")
+    print("<<<" + url_to_convert + ">>>")
 
-# download video
-# make it more sofisticated and configurable
-dir = home + '\\Videos\\YoutubeDownload\\'
-albumFolder = '%(creator)s - %(playlist_title)s\\'
-mp3albumFolder = '%(creator)s - %(playlist_title)s - audio\\'
-outtmpl = dir + albumFolder + '%(autonumber)s-%(title)s.%(ext)s'
-retries = 3
-cachedir = home + '\\Videos\\cacheYoutube\\'
-verbose = None
-format = 'mp4'
+    # download video
+    # make it more sofisticated and configurable
+    dir = home + '\\Videos\\YoutubeDownload\\'
+    albumFolder = '%(creator)s - %(playlist_title)s\\'
+    mp3albumFolder = '%(creator)s - %(playlist_title)s - audio\\'
+    outtmpl = dir + albumFolder + '%(autonumber)s-%(title)s.%(ext)s'
+    retries = 3
+    cachedir = home + '\\Videos\\cacheYoutube\\'
+    verbose = None
+    format = 'mp4'
 
-path_with_album = url_to_convert
-source_dir = Path(path_with_album + '\\')
-files = source_dir.glob('*.mp4')
-for file in files:
-    print(file.name)
-    filename = file.name.replace('.mp4', '.mp3')
-    audioDir = path_with_album + ' - audio\\'
-    extract_audio(input_path=file, output_path=audioDir + filename)
+    path_with_album = url_to_convert
+    source_dir = Path(path_with_album + '\\')
+    files = source_dir.glob('*.mp4')
+    for file in files:
+        print(file.name)
+        filename = file.name.replace('.mp4', '.mp3')
+        audioDir = path_with_album + ' - audio\\'
+        extract_audio(input_path=file, output_path=audioDir + filename)
+
+
+if __name__ == "__main__":
+    main()

--- a/cases/webs/openwebs.py
+++ b/cases/webs/openwebs.py
@@ -3,24 +3,29 @@
 import webbrowser
 import sys
 
-all = False
-if len(sys.argv) == 1:
-    all = True
 
-if all or 'init' in sys.argv:
-    webbrowser.open('https://mail.google.com')
-    webbrowser.open('https://calendar.google.com')
-    webbrowser.open('https://translate.google.com')
+def main():
+    all = False
+    if len(sys.argv) == 1:
+        all = True
+
+    if all or 'init' in sys.argv:
+        webbrowser.open('https://mail.google.com')
+        webbrowser.open('https://calendar.google.com')
+        webbrowser.open('https://translate.google.com')
+
+    if all or 's' in sys.argv:
+        webbrowser.open('https://facebook.com')
+        webbrowser.open('https://twitter.com')
+        webbrowser.open('https://linkedin.com')
+        webbrowser.open('https://pinterest.com')
+        webbrowser.open('https://azet.sk')
+
+    if all or 'n' in sys.argv:
+        webbrowser.open('https://hnonline.sk')
+        webbrowser.open('https://aktuality.sk')
+        webbrowser.open('https://sport.aktuality.sk')
 
 
-if all or 's' in sys.argv:
-    webbrowser.open('https://facebook.com')
-    webbrowser.open('https://twitter.com')
-    webbrowser.open('https://linkedin.com')
-    webbrowser.open('https://pinterest.com')
-    webbrowser.open('https://azet.sk')
-
-if all or 'n' in sys.argv:
-    webbrowser.open('https://hnonline.sk')
-    webbrowser.open('https://aktuality.sk')
-    webbrowser.open('https://sport.aktuality.sk')
+if __name__ == "__main__":
+    main()

--- a/cases/webs/pinterest.py
+++ b/cases/webs/pinterest.py
@@ -12,7 +12,7 @@ from pathlib import Path
 def main():
     home = str(Path.home())
     Config = configparser.ConfigParser()
-    Config.read(home + '\\BoringStuff.ini')
+    Config.read(str(Path(home) / 'BoringStuff.ini'))
 
     #obtain url of pinterest board
     url = Config.get('Pinterest','RandomBoard')

--- a/cases/webs/pinterest.py
+++ b/cases/webs/pinterest.py
@@ -8,19 +8,25 @@ import webbrowser
 import configparser
 from pathlib import Path
 
-home = str(Path.home())
-Config = configparser.ConfigParser()
-Config.read(home + '\\BoringStuff.ini')
 
-#obtain url of pinterest board
-url = Config.get('Pinterest','RandomBoard')
-response = requests.get(url, "xml")
-response.raise_for_status()
+def main():
+    home = str(Path.home())
+    Config = configparser.ConfigParser()
+    Config.read(home + '\\BoringStuff.ini')
 
-#xml response parse it
-doc = xmltodict.parse(response.content)
-size = len(doc['rss']['channel']['item'])
-picture = doc['rss']['channel']['item'][random.randint(0, size)]
-print(picture)
-webbrowser.open(picture['link'])
+    #obtain url of pinterest board
+    url = Config.get('Pinterest','RandomBoard')
+    response = requests.get(url, "xml")
+    response.raise_for_status()
+
+    #xml response parse it
+    doc = xmltodict.parse(response.content)
+    size = len(doc['rss']['channel']['item'])
+    picture = doc['rss']['channel']['item'][random.randint(0, size)]
+    print(picture)
+    webbrowser.open(picture['link'])
+
+
+if __name__ == "__main__":
+    main()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,9 @@ dependencies = [
     "pillow>=12.3.0",
     "pyperclip>=1.11.0",
     "pywin32>=312; sys_platform == 'win32'",
+    "xmltodict>=1.0.4",
+    "audio-extract>=0.7.0",
+    "setuptools<80",
 ]
 
 [project.scripts]
@@ -21,6 +24,12 @@ clipsave = "wins.clipsave:main"
 b64d = "devs.base64_clip:main_decode"
 b64e = "devs.base64_clip:main_encode"
 prune-branches = "devs.prune_branches:main"
+lucky = "cases.webs.lucky:main"
+mapit = "cases.maps.mapit:main"
+negative = "cases.pictures.negative:main"
+pinterest = "cases.webs.pinterest:main"
+openwebs = "cases.webs.openwebs:main"
+mp4to3 = "cases.webs.mp4to3:main"
 
 [tool.setuptools]
 packages = []  # Tells it not to look for library packages

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -44,11 +44,30 @@ Run command:
     mapit  (takes address from clipboard)
     mapit Bratislava
 
+#### Mp4to3
+Extract mp3 audio from every .mp4 file already sitting in a folder (doesn't
+download anything itself - see `youtube -a` for downloading + extracting in
+one step).
+
+Run command:
+
+    mp4to3 [folder]
+
 #### Negative
 Invert picture in negative colors.
 Run command:
 
     negative [directory_with_picture]
+
+#### Openwebs
+Open a batch of your usual sites in the browser, grouped by tag.
+
+Run command:
+
+    openwebs         (opens all groups)
+    openwebs init    (mail/calendar/translate)
+    openwebs s       (social sites)
+    openwebs n       (news sites)
 
 #### Pinterest
 Open random picture from pinteres board

--- a/scripts/lucky.bat
+++ b/scripts/lucky.bat
@@ -1,1 +1,0 @@
-@python %BORING_STUFF_PATH%\cases\webs\lucky.py %*

--- a/scripts/mapit.bat
+++ b/scripts/mapit.bat
@@ -1,1 +1,0 @@
-@python %BORING_STUFF_PATH%\cases\maps\mapit.py %*

--- a/scripts/mp4to3.bat
+++ b/scripts/mp4to3.bat
@@ -1,1 +1,0 @@
-@python %BORING_STUFF_PATH%\cases\webs\mp4to3.py %*

--- a/scripts/negative.bat
+++ b/scripts/negative.bat
@@ -1,1 +1,0 @@
-@python %BORING_STUFF_PATH%\case\pictures\negative.py %*

--- a/scripts/openwebs.bat
+++ b/scripts/openwebs.bat
@@ -1,1 +1,0 @@
-@python %BORING_STUFF_PATH%\cases\webs\openwebs.py %*

--- a/scripts/pinterest.bat
+++ b/scripts/pinterest.bat
@@ -1,1 +1,0 @@
-@python %BORING_STUFF_PATH%\cases\webs\pinterest.py %*

--- a/tests/test_mapit.py
+++ b/tests/test_mapit.py
@@ -1,0 +1,31 @@
+import pytest
+
+pytest.importorskip("tkinter")
+
+from cases.maps import mapit
+
+
+def test_uses_argv_address_when_given(monkeypatch):
+    opened = []
+    monkeypatch.setattr(mapit.webbrowser, "open", lambda url: opened.append(url))
+    monkeypatch.setattr(mapit.sys, "argv", ["mapit", "Bratislava"])
+
+    mapit.main()
+
+    assert opened == ["https://www.google.com/maps/place/Bratislava"]
+
+
+def test_falls_back_to_clipboard_when_no_args(monkeypatch):
+    opened = []
+    monkeypatch.setattr(mapit.webbrowser, "open", lambda url: opened.append(url))
+    monkeypatch.setattr(mapit.sys, "argv", ["mapit"])
+
+    class FakeRoot:
+        def clipboard_get(self):
+            return "Vienna"
+
+    monkeypatch.setattr(mapit.tk, "Tk", lambda: FakeRoot())
+
+    mapit.main()
+
+    assert opened == ["https://www.google.com/maps/place/Vienna"]

--- a/tests/test_mp4to3.py
+++ b/tests/test_mp4to3.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from cases.webs import mp4to3
+
+
+def test_extracts_audio_for_each_mp4_in_folder(tmp_path, monkeypatch):
+    (tmp_path / "song1.mp4").write_bytes(b"")
+    (tmp_path / "song2.mp4").write_bytes(b"")
+
+    calls = []
+    monkeypatch.setattr(
+        mp4to3, "extract_audio",
+        lambda input_path, output_path: calls.append((str(input_path), output_path)),
+    )
+    monkeypatch.setattr(mp4to3.sys, "argv", ["mp4to3", str(tmp_path)])
+
+    mp4to3.main()
+
+    assert len(calls) == 2
+    names = {Path(c[0]).name for c in calls}
+    assert names == {"song1.mp4", "song2.mp4"}

--- a/tests/test_mp4to3.py
+++ b/tests/test_mp4to3.py
@@ -19,3 +19,8 @@ def test_extracts_audio_for_each_mp4_in_folder(tmp_path, monkeypatch):
     assert len(calls) == 2
     names = {Path(c[0]).name for c in calls}
     assert names == {"song1.mp4", "song2.mp4"}
+
+    expected_audio_dir = Path(f"{tmp_path} - audio")
+    for _input_path, output_path in calls:
+        assert Path(output_path).parent == expected_audio_dir
+        assert output_path.endswith(".mp3")

--- a/tests/test_negative.py
+++ b/tests/test_negative.py
@@ -1,0 +1,24 @@
+from PIL import Image
+
+from cases.pictures import negative
+
+
+def test_creates_negative_for_each_image(tmp_path, monkeypatch):
+    img = Image.new("RGB", (4, 4), color=(10, 20, 30))
+    img.save(tmp_path / "pic.png")
+
+    monkeypatch.setattr(negative.sys, "argv", ["negative", str(tmp_path)])
+    negative.main()
+
+    out_path = tmp_path / "negativepic.png"
+    assert out_path.exists()
+    inverted = Image.open(out_path)
+    assert inverted.getpixel((0, 0)) == (245, 235, 225)
+
+
+def test_prints_message_when_no_args(monkeypatch, capsys):
+    monkeypatch.setattr(negative.sys, "argv", ["negative"])
+    negative.main()
+
+    out = capsys.readouterr().out
+    assert "No parameter was inserted." in out

--- a/tests/test_openwebs.py
+++ b/tests/test_openwebs.py
@@ -1,0 +1,28 @@
+from cases.webs import openwebs
+
+
+def test_no_args_opens_all_three_groups(monkeypatch):
+    opened = []
+    monkeypatch.setattr(openwebs.webbrowser, "open", lambda url: opened.append(url))
+    monkeypatch.setattr(openwebs.sys, "argv", ["openwebs"])
+
+    openwebs.main()
+
+    assert len(opened) == 3 + 5 + 3
+    assert "https://mail.google.com" in opened
+    assert "https://facebook.com" in opened
+    assert "https://hnonline.sk" in opened
+
+
+def test_specific_group_only(monkeypatch):
+    opened = []
+    monkeypatch.setattr(openwebs.webbrowser, "open", lambda url: opened.append(url))
+    monkeypatch.setattr(openwebs.sys, "argv", ["openwebs", "init"])
+
+    openwebs.main()
+
+    assert opened == [
+        "https://mail.google.com",
+        "https://calendar.google.com",
+        "https://translate.google.com",
+    ]

--- a/tests/test_pinterest.py
+++ b/tests/test_pinterest.py
@@ -1,0 +1,32 @@
+from cases.webs import pinterest
+
+
+def test_opens_random_picture_link(tmp_path, monkeypatch):
+    ini = tmp_path / "BoringStuff.ini"
+    ini.write_text(
+        "[Pinterest]\nRandomBoard: https://example.com/board.rss\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(pinterest.Path, "home", lambda: tmp_path)
+
+    # Two <item> entries so xmltodict parses a list (a single <item> would
+    # parse as a plain dict instead, which the script doesn't handle).
+    xml_response = b"""<rss><channel>
+        <item><title>a</title><link>https://example.com/a.jpg</link></item>
+        <item><title>b</title><link>https://example.com/b.jpg</link></item>
+    </channel></rss>"""
+
+    class FakeResponse:
+        content = xml_response
+
+        def raise_for_status(self):
+            pass
+
+    monkeypatch.setattr(pinterest.requests, "get", lambda url, fmt: FakeResponse())
+    monkeypatch.setattr(pinterest.random, "randint", lambda a, b: 0)
+    opened = []
+    monkeypatch.setattr(pinterest.webbrowser, "open", lambda url: opened.append(url))
+
+    pinterest.main()
+
+    assert opened == ["https://example.com/a.jpg"]

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,20 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
+name = "audio-extract"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ffmpeg-python" },
+    { name = "imageio-ffmpeg" },
+    { name = "mutagen" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/7b/e2d7b3bb9005efe3c1307f512c0f37572c067187c6690080b1ae9b2c9ac5/audio_extract-0.7.0.tar.gz", hash = "sha256:bf8d5f48146e2d4d15778a26cede57b303f465f299621539118448bc22100dbb", size = 6998, upload-time = "2024-09-25T23:48:15.35Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/85/5433110bf0eb71151782694098b818b4f0b26fd2992623881694fd8a6a09/audio_extract-0.7.0-py3-none-any.whl", hash = "sha256:44495569a86e46a94d1606214d39abebc30db59ed207b8b900787c2e844a887d", size = 7466, upload-time = "2024-09-25T23:48:13.717Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -20,6 +34,7 @@ name = "boring-stuff"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "audio-extract" },
     { name = "googlesearch-python" },
     { name = "openpyxl" },
     { name = "pillow" },
@@ -27,6 +42,8 @@ dependencies = [
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "pyyaml" },
     { name = "quickjs" },
+    { name = "setuptools" },
+    { name = "xmltodict" },
     { name = "yt-dlp" },
 ]
 
@@ -37,6 +54,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "audio-extract", specifier = ">=0.7.0" },
     { name = "googlesearch-python", specifier = ">=1.3.0" },
     { name = "openpyxl" },
     { name = "pillow", specifier = ">=12.3.0" },
@@ -44,6 +62,8 @@ requires-dist = [
     { name = "pywin32", marker = "sys_platform == 'win32'", specifier = ">=312" },
     { name = "pyyaml" },
     { name = "quickjs", specifier = ">=1.19.4" },
+    { name = "setuptools", specifier = "<80" },
+    { name = "xmltodict", specifier = ">=1.0.4" },
     { name = "yt-dlp", extras = ["build-in-js-interpreter", "javascript"], specifier = ">=2026.3.17" },
 ]
 
@@ -209,6 +229,27 @@ wheels = [
 ]
 
 [[package]]
+name = "ffmpeg-python"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "future" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/5e/d5f9105d59c1325759d838af4e973695081fbbc97182baf73afc78dec266/ffmpeg-python-0.2.0.tar.gz", hash = "sha256:65225db34627c578ef0e11c8b1eb528bb35e024752f6f10b78c011f6f64c4127", size = 21543, upload-time = "2019-07-06T00:19:08.989Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/0c/56be52741f75bad4dc6555991fabd2e07b432d333da82c11ad701123888a/ffmpeg_python-0.2.0-py3-none-any.whl", hash = "sha256:ac441a0404e053f8b6a1113a77c0f452f1cfc62f6344a769475ffdc0f56c23c5", size = 25024, upload-time = "2019-07-06T00:19:07.215Z" },
+]
+
+[[package]]
+name = "future"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/b2/4140c69c6a66432916b26158687e821ba631a4c9273c474343badf84d3ba/future-1.0.0.tar.gz", hash = "sha256:bd2968309307861edae1458a4f8a4f3598c03be43b97521076aebf5d94c07b05", size = 1228490, upload-time = "2024-02-21T11:52:38.461Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/71/ae30dadffc90b9006d77af76b393cb9dfbfc9629f339fc1574a1c52e6806/future-1.0.0-py3-none-any.whl", hash = "sha256:929292d34f5872e70396626ef385ec22355a1fae8ad29e1a734c3e43f9fbc216", size = 491326, upload-time = "2024-02-21T11:52:35.956Z" },
+]
+
+[[package]]
 name = "googlesearch-python"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -231,12 +272,34 @@ wheels = [
 ]
 
 [[package]]
+name = "imageio-ffmpeg"
+version = "0.4.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/a2/46e01fb2cae3a14ccc7f3af8ac95d7bab20d9759b734b5a861bff48a7a51/imageio-ffmpeg-0.4.8.tar.gz", hash = "sha256:fdaa05ad10fe070b7fa8e5f615cb0d28f3b9b791d00af6d2a11e694158d10aa9", size = 17224, upload-time = "2023-01-09T20:35:18.02Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/ff/11f41411650d32b9d7051b41d8de6f6eb671e031214b09c1aaa47389682d/imageio_ffmpeg-0.4.8-py3-none-macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:dba439a303d65061aef17d2ee9324ecfa9c6b4752bd0953b309fdbb79b38451e", size = 22532537, upload-time = "2023-01-09T20:35:10.238Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/3f/fc9a0345a0ef2d9596c3d3d9549ac72377ea97c289abcf3c96f0821c3072/imageio_ffmpeg-0.4.8-py3-none-manylinux2010_x86_64.whl", hash = "sha256:7caa9ce9fc0d7e2f3160ce8cb70a115e5211e0f048e5c1509163d8f89d1080df", size = 26900001, upload-time = "2023-01-09T20:35:15.999Z" },
+    { url = "https://files.pythonhosted.org/packages/41/27/75db3fa1ced57e644e942e2f7486dca70b3b27f4a5da9f8c2d8e5464c842/imageio_ffmpeg-0.4.8-py3-none-manylinux2014_aarch64.whl", hash = "sha256:dd3ef9835df91570a1cbd9e36dfbc7d228fca42dbb11636e20df75d719de2949", size = 22880069, upload-time = "2023-01-09T20:35:03.52Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/3f/0468065ee9080f11edd355a5eddadb6f32ca37a7ca81223eaefbfb63b8b6/imageio_ffmpeg-0.4.8-py3-none-win32.whl", hash = "sha256:0e2688120b3bdb367897450d07c1b1300e96a0bace03ba7de2eb8d738237ea9a", size = 19651713, upload-time = "2023-01-09T20:35:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/1d/9d9bb0beef06704cb3acb7cab8673b451d4528ee6cc9b231d1284aa1ed75/imageio_ffmpeg-0.4.8-py3-none-win_amd64.whl", hash = "sha256:120d70e6448617cad6213e47dee3a3310117c230f532dd614ed3059a78acf13a", size = 22619501, upload-time = "2023-01-09T20:35:06.778Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "mutagen"
+version = "1.46.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/54/d1760a363d0fe345528e37782f6c18123b0e99e8ea755022fd51f1ecd0f9/mutagen-1.46.0.tar.gz", hash = "sha256:6e5f8ba84836b99fe60be5fb27f84be4ad919bbb6b49caa6ae81e70584b55e58", size = 1268561, upload-time = "2022-10-09T17:58:15.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/ee/114d7016d2e34f341e212fefb5e7bd87785077ebcfff0ad23a497c70eea1/mutagen-1.46.0-py3-none-any.whl", hash = "sha256:8af0728aa2d5c3ee5a727e28d0627966641fddfe804c23eabb5926a4d770aed5", size = 193643, upload-time = "2022-10-09T17:58:11.72Z" },
 ]
 
 [[package]]
@@ -467,6 +530,15 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "79.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/71/b6365e6325b3290e14957b2c3a804a529968c77a049b2ed40c095f749707/setuptools-79.0.1.tar.gz", hash = "sha256:128ce7b8f33c3079fd1b067ecbb4051a66e8526e7b65f6cec075dfc650ddfa88", size = 1367909, upload-time = "2025-04-23T22:20:59.241Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/6d/b4752b044bf94cb802d88a888dc7d288baaf77d7910b7dedda74b5ceea0c/setuptools-79.0.1-py3-none-any.whl", hash = "sha256:e147c0549f27767ba362f9da434eab9c5dc0045d5304feb602a0af001089fc51", size = 1256281, upload-time = "2025-04-23T22:20:56.768Z" },
+]
+
+[[package]]
 name = "soupsieve"
 version = "2.9.2"
 source = { registry = "https://pypi.org/simple" }
@@ -491,6 +563,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "xmltodict"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/70/80f3b7c10d2630aa66414bf23d210386700aa390547278c789afa994fd7e/xmltodict-1.0.4.tar.gz", hash = "sha256:6d94c9f834dd9e44514162799d344d815a3a4faec913717a9ecbfa5be1bb8e61", size = 26124, upload-time = "2026-02-22T02:21:22.074Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/34/98a2f52245f4d47be93b580dae5f9861ef58977d73a79eb47c58f1ad1f3a/xmltodict-1.0.4-py3-none-any.whl", hash = "sha256:a4a00d300b0e1c59fc2bfccb53d7b2e88c32f200df138a0dd2229f842497026a", size = 13580, upload-time = "2026-02-22T02:21:21.039Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Wraps each script's top-level code in main() and registers all six as proper console-script entries (same pattern as clipsave/b64d/b64e/prune-branches), removing the dependency on the unset BORING_STUFF_PATH env var. Removed the now-redundant, already-broken .bat shims. pinterest/mp4to3 also needed real dependency fixes (xmltodict, audio-extract were used but never declared; pinned setuptools<80 since imageio_ffmpeg still needs the now-removed pkg_resources). Added tests for all 6, mocking browser/network/tkinter/audio calls. 40/40 tests pass.