### PR TITLE
Drop audio-extract dependency chain, call ffmpeg directly

### DIFF
--- a/cases/webs/mp4to3.py
+++ b/cases/webs/mp4to3.py
@@ -4,6 +4,7 @@
 # mp4to3 [folder]
 
 import codecs
+import subprocess
 import sys
 import pathlib
 from pathlib import Path
@@ -11,8 +12,12 @@ from pathlib import Path
 # ffmpeg on system path
 # download ffmpeg: https://www.gyan.dev/ffmpeg/builds/
 # https://video.stackexchange.com/questions/20495/how-do-i-set-up-and-use-ffmpeg-in-windows
-import yt_dlp as youtube_dl
-from audio_extract import extract_audio
+
+
+def extract_audio(input_path, output_path):
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["ffmpeg", "-i", str(input_path), "-y", str(output_path)], check=True)
+
 
 def main():
     # Compatibility fixes for Windows

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,6 @@ dependencies = [
     "pyperclip>=1.11.0",
     "pywin32>=312; sys_platform == 'win32'",
     "xmltodict>=1.0.4",
-    "audio-extract>=0.7.0",
-    "setuptools<80",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -3,20 +3,6 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
-name = "audio-extract"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ffmpeg-python" },
-    { name = "imageio-ffmpeg" },
-    { name = "mutagen" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/76/7b/e2d7b3bb9005efe3c1307f512c0f37572c067187c6690080b1ae9b2c9ac5/audio_extract-0.7.0.tar.gz", hash = "sha256:bf8d5f48146e2d4d15778a26cede57b303f465f299621539118448bc22100dbb", size = 6998, upload-time = "2024-09-25T23:48:15.35Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/85/5433110bf0eb71151782694098b818b4f0b26fd2992623881694fd8a6a09/audio_extract-0.7.0-py3-none-any.whl", hash = "sha256:44495569a86e46a94d1606214d39abebc30db59ed207b8b900787c2e844a887d", size = 7466, upload-time = "2024-09-25T23:48:13.717Z" },
-]
-
-[[package]]
 name = "beautifulsoup4"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -34,7 +20,6 @@ name = "boring-stuff"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
-    { name = "audio-extract" },
     { name = "googlesearch-python" },
     { name = "openpyxl" },
     { name = "pillow" },
@@ -42,7 +27,6 @@ dependencies = [
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "pyyaml" },
     { name = "quickjs" },
-    { name = "setuptools" },
     { name = "xmltodict" },
     { name = "yt-dlp" },
 ]
@@ -54,7 +38,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "audio-extract", specifier = ">=0.7.0" },
     { name = "googlesearch-python", specifier = ">=1.3.0" },
     { name = "openpyxl" },
     { name = "pillow", specifier = ">=12.3.0" },
@@ -62,7 +45,6 @@ requires-dist = [
     { name = "pywin32", marker = "sys_platform == 'win32'", specifier = ">=312" },
     { name = "pyyaml" },
     { name = "quickjs", specifier = ">=1.19.4" },
-    { name = "setuptools", specifier = "<80" },
     { name = "xmltodict", specifier = ">=1.0.4" },
     { name = "yt-dlp", extras = ["build-in-js-interpreter", "javascript"], specifier = ">=2026.3.17" },
 ]
@@ -229,27 +211,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ffmpeg-python"
-version = "0.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "future" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/5e/d5f9105d59c1325759d838af4e973695081fbbc97182baf73afc78dec266/ffmpeg-python-0.2.0.tar.gz", hash = "sha256:65225db34627c578ef0e11c8b1eb528bb35e024752f6f10b78c011f6f64c4127", size = 21543, upload-time = "2019-07-06T00:19:08.989Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/0c/56be52741f75bad4dc6555991fabd2e07b432d333da82c11ad701123888a/ffmpeg_python-0.2.0-py3-none-any.whl", hash = "sha256:ac441a0404e053f8b6a1113a77c0f452f1cfc62f6344a769475ffdc0f56c23c5", size = 25024, upload-time = "2019-07-06T00:19:07.215Z" },
-]
-
-[[package]]
-name = "future"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a7/b2/4140c69c6a66432916b26158687e821ba631a4c9273c474343badf84d3ba/future-1.0.0.tar.gz", hash = "sha256:bd2968309307861edae1458a4f8a4f3598c03be43b97521076aebf5d94c07b05", size = 1228490, upload-time = "2024-02-21T11:52:38.461Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/71/ae30dadffc90b9006d77af76b393cb9dfbfc9629f339fc1574a1c52e6806/future-1.0.0-py3-none-any.whl", hash = "sha256:929292d34f5872e70396626ef385ec22355a1fae8ad29e1a734c3e43f9fbc216", size = 491326, upload-time = "2024-02-21T11:52:35.956Z" },
-]
-
-[[package]]
 name = "googlesearch-python"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -272,34 +233,12 @@ wheels = [
 ]
 
 [[package]]
-name = "imageio-ffmpeg"
-version = "0.4.8"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/a2/46e01fb2cae3a14ccc7f3af8ac95d7bab20d9759b734b5a861bff48a7a51/imageio-ffmpeg-0.4.8.tar.gz", hash = "sha256:fdaa05ad10fe070b7fa8e5f615cb0d28f3b9b791d00af6d2a11e694158d10aa9", size = 17224, upload-time = "2023-01-09T20:35:18.02Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/ff/11f41411650d32b9d7051b41d8de6f6eb671e031214b09c1aaa47389682d/imageio_ffmpeg-0.4.8-py3-none-macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:dba439a303d65061aef17d2ee9324ecfa9c6b4752bd0953b309fdbb79b38451e", size = 22532537, upload-time = "2023-01-09T20:35:10.238Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/3f/fc9a0345a0ef2d9596c3d3d9549ac72377ea97c289abcf3c96f0821c3072/imageio_ffmpeg-0.4.8-py3-none-manylinux2010_x86_64.whl", hash = "sha256:7caa9ce9fc0d7e2f3160ce8cb70a115e5211e0f048e5c1509163d8f89d1080df", size = 26900001, upload-time = "2023-01-09T20:35:15.999Z" },
-    { url = "https://files.pythonhosted.org/packages/41/27/75db3fa1ced57e644e942e2f7486dca70b3b27f4a5da9f8c2d8e5464c842/imageio_ffmpeg-0.4.8-py3-none-manylinux2014_aarch64.whl", hash = "sha256:dd3ef9835df91570a1cbd9e36dfbc7d228fca42dbb11636e20df75d719de2949", size = 22880069, upload-time = "2023-01-09T20:35:03.52Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/3f/0468065ee9080f11edd355a5eddadb6f32ca37a7ca81223eaefbfb63b8b6/imageio_ffmpeg-0.4.8-py3-none-win32.whl", hash = "sha256:0e2688120b3bdb367897450d07c1b1300e96a0bace03ba7de2eb8d738237ea9a", size = 19651713, upload-time = "2023-01-09T20:35:12.735Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/1d/9d9bb0beef06704cb3acb7cab8673b451d4528ee6cc9b231d1284aa1ed75/imageio_ffmpeg-0.4.8-py3-none-win_amd64.whl", hash = "sha256:120d70e6448617cad6213e47dee3a3310117c230f532dd614ed3059a78acf13a", size = 22619501, upload-time = "2023-01-09T20:35:06.778Z" },
-]
-
-[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
-]
-
-[[package]]
-name = "mutagen"
-version = "1.46.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b1/54/d1760a363d0fe345528e37782f6c18123b0e99e8ea755022fd51f1ecd0f9/mutagen-1.46.0.tar.gz", hash = "sha256:6e5f8ba84836b99fe60be5fb27f84be4ad919bbb6b49caa6ae81e70584b55e58", size = 1268561, upload-time = "2022-10-09T17:58:15.219Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/ee/114d7016d2e34f341e212fefb5e7bd87785077ebcfff0ad23a497c70eea1/mutagen-1.46.0-py3-none-any.whl", hash = "sha256:8af0728aa2d5c3ee5a727e28d0627966641fddfe804c23eabb5926a4d770aed5", size = 193643, upload-time = "2022-10-09T17:58:11.72Z" },
 ]
 
 [[package]]
@@ -527,15 +466,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
-]
-
-[[package]]
-name = "setuptools"
-version = "79.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bb/71/b6365e6325b3290e14957b2c3a804a529968c77a049b2ed40c095f749707/setuptools-79.0.1.tar.gz", hash = "sha256:128ce7b8f33c3079fd1b067ecbb4051a66e8526e7b65f6cec075dfc650ddfa88", size = 1367909, upload-time = "2025-04-23T22:20:59.241Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/6d/b4752b044bf94cb802d88a888dc7d288baaf77d7910b7dedda74b5ceea0c/setuptools-79.0.1-py3-none-any.whl", hash = "sha256:e147c0549f27767ba362f9da434eab9c5dc0045d5304feb602a0af001089fc51", size = 1256281, upload-time = "2025-04-23T22:20:56.768Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
audio-extract's extract_audio() turned out to be just subprocess.run(['ffmpeg', ...]) with imageio_ffmpeg only used to locate the binary - redundant here since ffmpeg is already required on PATH for yt-dlp. audio-extract also hard-pins imageio-ffmpeg==0.4.8 (exact) and looks unmaintained, so even a future imageio-ffmpeg fix wouldn't be reachable anyway. Replaced with a small local extract_audio() that shells out to ffmpeg directly - removes 5 dependencies plus the setuptools<80 pin entirely. Verified end-to-end with a real ffmpeg call (synthetic test video -> real mp3). All 40 tests pass, no more pkg_resources deprecation warning.