### PR TITLE
Fix taskbar icon: stale pinned copy + timeout.exe/ConPTY bug

### DIFF
--- a/cases/README.md
+++ b/cases/README.md
@@ -8,7 +8,7 @@ hand every time.
 ## Add Boring Stuff to Taskbar in windows
 A pinned taskbar shortcut ("B" icon): left-click runs `clipsave`, right-click
 shows a Jump List menu with `b64d`/`b64e`. Each opens a terminal window that
-shows the result and closes itself after 60 seconds (or on any keypress).
+shows the result and closes itself after 60 seconds.
 
 One-time setup:
 

--- a/cases/devs/taskbar/run_b64d.bat
+++ b/cases/devs/taskbar/run_b64d.bat
@@ -2,5 +2,5 @@
 title Boring - b64d
 "%~dp0..\..\..\.venv\Scripts\b64d.exe"
 echo.
-echo Closing in 60 seconds - press any key to close now.
-timeout /t 60
+echo Closing in 60 seconds...
+ping -n 61 127.0.0.1 >nul

--- a/cases/devs/taskbar/run_b64e.bat
+++ b/cases/devs/taskbar/run_b64e.bat
@@ -2,5 +2,5 @@
 title Boring - b64e
 "%~dp0..\..\..\.venv\Scripts\b64e.exe"
 echo.
-echo Closing in 60 seconds - press any key to close now.
-timeout /t 60
+echo Closing in 60 seconds...
+ping -n 61 127.0.0.1 >nul

--- a/cases/devs/taskbar/run_clipsave.bat
+++ b/cases/devs/taskbar/run_clipsave.bat
@@ -2,5 +2,5 @@
 title Boring - clipsave
 "%~dp0..\..\..\.venv\Scripts\clipsave.exe"
 echo.
-echo Closing in 60 seconds - press any key to close now.
-timeout /t 60
+echo Closing in 60 seconds...
+ping -n 61 127.0.0.1 >nul


### PR DESCRIPTION
Two separate bugs behind 'left-click opens a terminal that immediately closes': (1) the pinned taskbar shortcut is Windows' own independent copy, separate from the source .lnk the setup script regenerates - it still pointed at the pre-restructure devs/taskbar path, fixed directly on this machine and confirmed AppUserModelID (Jump List) survived; (2) timeout /t 60 fails immediately under Windows Terminal's ConPTY (hit this myself while testing) - replaced with a ping-based sleep that has no console-handle dependency, trading the early-keypress-close nicety for reliability. Verified via a real separate process (not inherited from a tool shell) that the window now stays open and clipsave's output saves correctly. All 40 tests pass.