### PR TITLE
Fix dependency and packaging gaps

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -16,7 +16,6 @@ Running list of things discussed but not yet done. Remove an item once it's buil
 
 ## Known bugs/gaps
 
-- `clean-logs` console script in `pyproject.toml` points to `scripts.cleanup:run`, which doesn't exist - crashes if run
 - `scripts/hello.py` throws `UnicodeEncodeError` on this console's codepage (emoji in a `print`)
 - `mapit.py`/`negative.py` lack basic error handling (empty clipboard, non-image files in a directory)
 
@@ -46,21 +45,6 @@ Grouped roughly by payoff; each item names the file it applies to.
   used, and `DIR_PATH` is hardcoded to `c:\repositories\_backgroundPics\`.
 - [cases/maps/mapit.py](cases/maps/mapit.py) - address is not URL-encoded, so
   addresses with `&`, `#` or `+` build a broken Maps URL.
-
-## Dependency and packaging
-
-- `requests` is imported by [cases/webs/pinterest.py](cases/webs/pinterest.py) but not
-  declared in `pyproject.toml` - it only resolves as a transitive dependency of
-  `googlesearch-python`. Declare it explicitly.
-- `pyproject.toml` has no `requires-python`; `uv` warns and defaults to `>=3.12` on
-  every run. Add `requires-python = ">=3.12"`.
-- `[tool.setuptools] packages = []` / `py-modules = []` means `cases` and `core` are
-  never packaged. The console scripts only work because of the editable install plus
-  the `sys.path` hack in [conftest.py](conftest.py); a normal (non-editable) install
-  would produce entry points that fail to import. Either declare the packages
-  properly or document that editable-only is intentional.
-- `clean-logs` in `[project.scripts]` points at `scripts.cleanup:run`, which does not
-  exist (`scripts/` contains only `hello.py`) - already tracked above, still open.
 
 ## Robustness / UX
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,11 @@
 [project]
 name = "boring-stuff"
 version = "0.1.0"
+requires-python = ">=3.12"
 dependencies = [
     "pyyaml",
     "openpyxl",
+    "requests>=2.34.2",
     "yt-dlp[build-in-js-interpreter,javascript]>=2026.3.17",
     "quickjs>=1.19.4",
     "googlesearch-python>=1.3.0",
@@ -15,7 +17,6 @@ dependencies = [
 
 [project.scripts]
 hello = "scripts.hello:main"
-clean-logs = "scripts.cleanup:run"
 youtube = "cases.webs.youtube:main"
 yt = "cases.webs.youtube:main"
 clipsave = "cases.wins.clipsave:main"
@@ -29,9 +30,9 @@ pinterest = "cases.webs.pinterest:main"
 openwebs = "cases.webs.openwebs:main"
 mp4to3 = "cases.webs.mp4to3:main"
 
-[tool.setuptools]
-packages = []  # Tells it not to look for library packages
-py-modules = [] # Tells it not to look for top-level modules
+[tool.setuptools.packages.find]
+include = ["cases*", "core*", "scripts*"]
+namespaces = true
 
 [tool.uv]
 package = true

--- a/uv.lock
+++ b/uv.lock
@@ -27,6 +27,7 @@ dependencies = [
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "pyyaml" },
     { name = "quickjs" },
+    { name = "requests" },
     { name = "xmltodict" },
     { name = "yt-dlp" },
 ]
@@ -45,6 +46,7 @@ requires-dist = [
     { name = "pywin32", marker = "sys_platform == 'win32'", specifier = ">=312" },
     { name = "pyyaml" },
     { name = "quickjs", specifier = ">=1.19.4" },
+    { name = "requests", specifier = ">=2.34.2" },
     { name = "xmltodict", specifier = ">=1.0.4" },
     { name = "yt-dlp", extras = ["build-in-js-interpreter", "javascript"], specifier = ">=2026.3.17" },
 ]


### PR DESCRIPTION
Declares requests explicitly, adds requires-python >=3.12, and fixes the real bug: [tool.setuptools] packages=[] meant a non-editable install would produce broken entry points (verified by building the wheel before/after - it went from containing zero source files to containing every needed module). Removed the dead clean-logs entry point rather than inventing an unspecified feature. Also verified the fix with a real fresh, non-editable venv install - all 12 console scripts present and working. All 50 tests pass.