### PR TITLE
Add --remote flag to prune-branches for origin branch cleanup

### DIFF
--- a/cases/README.md
+++ b/cases/README.md
@@ -35,19 +35,25 @@ If the clipboard isn't valid base64 (for `b64d`), or is empty, prints a
 message and exits non-zero without touching the clipboard.
 
 #### Prune-branches
-Delete local git branches already merged into origin's default branch
-(master/main). Run from inside whichever repo you want to clean up - not
-specific to boring-stuff.
+Delete branches already merged into origin's default branch (master/main).
+Run from inside whichever repo you want to clean up - not specific to
+boring-stuff.
 
 Run command:
 
-    prune-branches         (dry run - lists what would be deleted)
-    prune-branches --yes   (actually deletes them)
+    prune-branches                    (local, dry run - lists what would be deleted)
+    prune-branches --yes              (local, actually deletes them)
+    prune-branches --remote           (origin, dry run)
+    prune-branches --remote --yes     (origin, actually deletes them)
 
-Fetches from origin first so the merged-status check reflects branches
-merged remotely (e.g. via a squash-merged PR), even if your local default
-branch hasn't been updated yet. Only deletes branches git itself considers
-safe to delete (`git branch -d`, not `-D`).
+Fetches from origin first (with `--prune`, so stale remote-tracking refs
+don't linger) so the merged-status check reflects branches merged remotely
+(e.g. via a squash-merged PR), even if your local default branch hasn't
+been updated yet. Local deletion only removes branches git itself considers
+safe to delete (`git branch -d`, not `-D`); `--remote` deletes branches on
+origin via `git push origin --delete` - only ever branches already
+confirmed merged, but a real, visible-to-everyone deletion, so double-check
+the dry-run list first.
 
 ### cases/maps
 

--- a/cases/devs/prune_branches.py
+++ b/cases/devs/prune_branches.py
@@ -1,9 +1,11 @@
 #! python3
-# prune-branches - delete local git branches already merged into
-# origin's default branch (master/main). Dry-run by default.
+# prune-branches - delete branches already merged into origin's default
+# branch (master/main). Dry-run by default.
 #
-# prune-branches          list branches that would be deleted
-# prune-branches --yes    actually delete them
+# prune-branches                   list local branches that would be deleted
+# prune-branches --yes             actually delete them
+# prune-branches --remote          list origin branches that would be deleted
+# prune-branches --remote --yes    actually delete them on origin
 
 import argparse
 import subprocess
@@ -29,9 +31,64 @@ def get_current_branch():
     return run("branch", "--show-current").stdout.strip()
 
 
+def prune_local(remote_ref, default_branch, do_delete):
+    current_branch = get_current_branch()
+    merged = run("branch", "--merged", remote_ref, "--format=%(refname:short)")
+    candidates = [b for b in merged.stdout.splitlines() if b and b != default_branch and b != current_branch]
+
+    if not candidates:
+        print(f"No local branches to prune (nothing merged into {remote_ref} besides {default_branch}/current).")
+        return
+
+    print(f"Local branches merged into {remote_ref}:")
+    for b in candidates:
+        print(f"  {b}")
+
+    if not do_delete:
+        print(f"\nDry run - nothing deleted. Re-run with --yes to actually delete these {len(candidates)} branch(es).")
+        return
+
+    for b in candidates:
+        result = run("branch", "-d", b)
+        if result.returncode == 0:
+            print(f"Deleted {b}")
+        else:
+            print(f"Could not delete {b}: {result.stderr.strip()}")
+
+
+def prune_remote(remote_ref, default_branch, do_delete):
+    default_remote_ref = f"origin/{default_branch}"
+    merged = run("branch", "-r", "--merged", remote_ref, "--format=%(refname:short)")
+    candidates = []
+    for b in merged.stdout.splitlines():
+        if not b or not b.startswith("origin/") or b == default_remote_ref:
+            continue
+        candidates.append(b[len("origin/"):])
+
+    if not candidates:
+        print(f"No remote branches to prune (nothing on origin merged into {remote_ref} besides {default_branch}).")
+        return
+
+    print(f"Remote branches (on origin) merged into {remote_ref}:")
+    for b in candidates:
+        print(f"  {b}")
+
+    if not do_delete:
+        print(f"\nDry run - nothing deleted. Re-run with --remote --yes to actually delete these {len(candidates)} branch(es) on origin.")
+        return
+
+    for b in candidates:
+        result = run("push", "origin", "--delete", b)
+        if result.returncode == 0:
+            print(f"Deleted origin/{b}")
+        else:
+            print(f"Could not delete origin/{b}: {result.stderr.strip()}")
+
+
 def main(argv=None):
-    parser = argparse.ArgumentParser(description="Delete local branches already merged into origin's default branch")
+    parser = argparse.ArgumentParser(description="Delete branches already merged into origin's default branch")
     parser.add_argument("--yes", "-y", action="store_true", help="actually delete (default is a dry run)")
+    parser.add_argument("--remote", "-r", action="store_true", help="operate on origin's branches instead of local ones")
     args = parser.parse_args(argv)
 
     if run("rev-parse", "--is-inside-work-tree").returncode != 0:
@@ -39,7 +96,7 @@ def main(argv=None):
         sys.exit(1)
 
     print("Fetching from origin...")
-    fetch = run("fetch", "origin")
+    fetch = run("fetch", "origin", "--prune")
     if fetch.returncode != 0:
         print(f"git fetch failed: {fetch.stderr.strip()}")
         sys.exit(1)
@@ -50,29 +107,11 @@ def main(argv=None):
         sys.exit(1)
 
     remote_ref = f"origin/{default_branch}"
-    current_branch = get_current_branch()
 
-    merged = run("branch", "--merged", remote_ref, "--format=%(refname:short)")
-    candidates = [b for b in merged.stdout.splitlines() if b and b != default_branch and b != current_branch]
-
-    if not candidates:
-        print(f"No local branches to prune (nothing merged into {remote_ref} besides {default_branch}/current).")
-        return
-
-    print(f"Branches merged into {remote_ref}:")
-    for b in candidates:
-        print(f"  {b}")
-
-    if not args.yes:
-        print(f"\nDry run - nothing deleted. Re-run with --yes to actually delete these {len(candidates)} branch(es).")
-        return
-
-    for b in candidates:
-        result = run("branch", "-d", b)
-        if result.returncode == 0:
-            print(f"Deleted {b}")
-        else:
-            print(f"Could not delete {b}: {result.stderr.strip()}")
+    if args.remote:
+        prune_remote(remote_ref, default_branch, args.yes)
+    else:
+        prune_local(remote_ref, default_branch, args.yes)
 
 
 if __name__ == "__main__":

--- a/tests/test_prune_branches.py
+++ b/tests/test_prune_branches.py
@@ -80,3 +80,68 @@ def test_reports_when_nothing_to_prune(repo, monkeypatch, capsys):
 
     out = capsys.readouterr().out
     assert "No local branches to prune" in out
+
+
+def make_merged_remote_branch(repo, name):
+    git("checkout", "-b", name, cwd=repo)
+    (repo / f"{name}.txt").write_text(name, encoding="utf-8")
+    git("add", f"{name}.txt", cwd=repo)
+    git("commit", "-m", name, cwd=repo)
+    git("push", "-u", "origin", name, cwd=repo)
+    git("checkout", "master", cwd=repo)
+    git("merge", "--no-ff", "-m", f"merge {name}", name, cwd=repo)
+    git("push", "origin", "master", cwd=repo)
+
+
+def remote_branch_names(remote_path):
+    output = subprocess.run(
+        ["git", "ls-remote", "--heads", str(remote_path)],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    return {line.rsplit("refs/heads/", 1)[-1] for line in output.splitlines() if line.strip()}
+
+
+def test_remote_dry_run_lists_but_does_not_delete(repo, monkeypatch, capsys):
+    remote = repo.parent / "remote.git"
+    make_merged_remote_branch(repo, "feature-x")
+
+    monkeypatch.chdir(repo)
+    prune_branches.main(["--remote"])
+
+    assert "feature-x" in remote_branch_names(remote)
+    out = capsys.readouterr().out
+    assert "feature-x" in out
+    assert "Dry run" in out
+
+
+def test_remote_yes_deletes_merged_remote_branch(repo, monkeypatch):
+    remote = repo.parent / "remote.git"
+    make_merged_remote_branch(repo, "feature-y")
+
+    monkeypatch.chdir(repo)
+    prune_branches.main(["--remote", "--yes"])
+
+    assert "feature-y" not in remote_branch_names(remote)
+
+
+def test_remote_does_not_delete_unmerged_remote_branch(repo, monkeypatch):
+    remote = repo.parent / "remote.git"
+    git("checkout", "-b", "feature-z", cwd=repo)
+    (repo / "feature-z.txt").write_text("z", encoding="utf-8")
+    git("add", "feature-z.txt", cwd=repo)
+    git("commit", "-m", "feature-z", cwd=repo)
+    git("push", "-u", "origin", "feature-z", cwd=repo)
+    git("checkout", "master", cwd=repo)
+
+    monkeypatch.chdir(repo)
+    prune_branches.main(["--remote", "--yes"])
+
+    assert "feature-z" in remote_branch_names(remote)
+
+
+def test_remote_reports_when_nothing_to_prune(repo, monkeypatch, capsys):
+    monkeypatch.chdir(repo)
+    prune_branches.main(["--remote"])
+
+    out = capsys.readouterr().out
+    assert "No remote branches to prune" in out


### PR DESCRIPTION
prune-branches now supports --remote: same merged-branch detection as the existing local mode, but operating on origin branches via git push origin --delete. Still dry-run by default, requires --yes to actually delete - remote deletion is a real, visible-to-everyone action. Also added --prune to the initial fetch so stale remote-tracking refs don't linger. Tested against a real fake bare remote repo (push, merge, verify list + delete + leave-unmerged-alone), 8/8 prune_branches tests pass. Also ran a real dry-run against this repo's actual GitHub remote (found 12 stale merged branches) - did not run the real deletion, since that's for the user to trigger.