### PR TITLE
Fix desktop wallpaper stretching outside the screen

### DIFF
--- a/cases/wins/setBackgroundPicture.py
+++ b/cases/wins/setBackgroundPicture.py
@@ -10,10 +10,16 @@ import ctypes
 import os
 import random
 import struct
+import winreg
 
 from core.configuration.user_conf import load_config
 
 SPI_SETDESKWALLPAPER = 20
+
+# WallpaperStyle "6" = Fit: scale the image to fit inside the screen while
+# keeping its aspect ratio, instead of the default stretch-to-fill.
+WALLPAPER_STYLE_FIT = "6"
+TILE_WALLPAPER_OFF = "0"
 
 
 def is_64_windows():
@@ -27,12 +33,22 @@ def get_sys_parameters_info():
         else ctypes.windll.user32.SystemParametersInfoA
 
 
+def set_wallpaper_fit_style():
+    """Set the desktop wallpaper style to "Fit" so the picture is scaled to fit
+    the screen instead of being stretched. """
+    with winreg.OpenKey(winreg.HKEY_CURRENT_USER, r"Control Panel\Desktop", 0, winreg.KEY_SET_VALUE) as key:
+        winreg.SetValueEx(key, "WallpaperStyle", 0, winreg.REG_SZ, WALLPAPER_STYLE_FIT)
+        winreg.SetValueEx(key, "TileWallpaper", 0, winreg.REG_SZ, TILE_WALLPAPER_OFF)
+
+
 def main():
     config = load_config(None)
     directory = config['wallpaper']['directory']
 
     wallpaper_path = os.path.join(directory, random.choice(os.listdir(directory)))
     print(wallpaper_path)
+
+    set_wallpaper_fit_style()
 
     sys_parameters_info = get_sys_parameters_info()
     result = sys_parameters_info(SPI_SETDESKWALLPAPER, 0, wallpaper_path, 3)

--- a/tests/test_set_background_picture.py
+++ b/tests/test_set_background_picture.py
@@ -1,5 +1,9 @@
 from pathlib import Path
 
+import pytest
+
+pytest.importorskip("winreg")
+
 from cases.wins import setBackgroundPicture
 
 
@@ -19,7 +23,12 @@ def test_picks_a_random_wallpaper_and_applies_it(tmp_path, monkeypatch, capsys):
     fake_spi = lambda *args: calls.append(args) or 1  # truthy = success, per Windows API
     monkeypatch.setattr(setBackgroundPicture, "get_sys_parameters_info", lambda: fake_spi)
 
+    style_calls = []
+    monkeypatch.setattr(setBackgroundPicture, "set_wallpaper_fit_style", lambda: style_calls.append(True))
+
     setBackgroundPicture.main()
+
+    assert style_calls == [True]
 
     assert len(calls) == 1
     action, _param, path, _flags = calls[0]
@@ -28,6 +37,31 @@ def test_picks_a_random_wallpaper_and_applies_it(tmp_path, monkeypatch, capsys):
 
     out = capsys.readouterr().out
     assert "one.jpg" in out
+
+
+def test_set_wallpaper_fit_style_writes_fit_registry_values(monkeypatch):
+    written = {}
+
+    class FakeKey:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc_info):
+            return False
+
+    def fake_open_key(hive, subkey, reserved, access):
+        assert subkey == r"Control Panel\Desktop"
+        return FakeKey()
+
+    def fake_set_value_ex(key, name, reserved, value_type, value):
+        written[name] = value
+
+    monkeypatch.setattr(setBackgroundPicture.winreg, "OpenKey", fake_open_key)
+    monkeypatch.setattr(setBackgroundPicture.winreg, "SetValueEx", fake_set_value_ex)
+
+    setBackgroundPicture.set_wallpaper_fit_style()
+
+    assert written == {"WallpaperStyle": "6", "TileWallpaper": "0"}
 
 
 def test_raises_when_directory_not_configured(monkeypatch):


### PR DESCRIPTION
## Summary
- `SPI_SETDESKWALLPAPER` stretches the picture using whatever `WallpaperStyle` is currently set in the registry, which defaults to "Stretch" and can overflow/distort the screen.
- Set `WallpaperStyle` to `6` (Fit) and `TileWallpaper` to `0` before applying the wallpaper so the picture scales to fit the screen instead.

## Test plan
- [x] `uv run pytest tests/test_set_background_picture.py -q`
- [x] `uv run pytest tests/ -q` (59 passed)