### PR TITLE
Fall back to CSS3/X11 color names for background <color>

### DIFF
--- a/cases/README.md
+++ b/cases/README.md
@@ -150,13 +150,16 @@ could be saved.
 
 #### Background
 Set your desktop background to a random picture from a configured folder, or
-to a solid color from a standard 12-color palette (red, orange, yellow,
-green, cyan, blue, purple, pink, brown, black, white, gray).
+to a solid color. A color name is first tried against a standard 12-color
+palette (red, orange, yellow, green, cyan, blue, purple, pink, brown, black,
+white, gray); if that doesn't match, it falls back to CSS3/X11 color names
+(e.g. `light blue`, `steelblue`), so most everyday color names work.
 
 Run command:
 
     background
     background green
+    background light blue
 
 Configuration (in `~/.boring-stuff/BoringStuff.yml`), only needed for the
 random-picture form:

--- a/cases/wins/background.py
+++ b/cases/wins/background.py
@@ -1,7 +1,9 @@
 #! python3
 # Set the desktop background:
 #   background          - a random picture from a configured directory
-#   background <color>  - a solid color, matched against a standard palette
+#   background <color>  - a solid color: first tried against a standard
+#                          12-color palette, then against CSS3/X11 color
+#                          names (e.g. "light blue", "steelblue")
 #
 # Configuration (in ~/.boring-stuff/BoringStuff.yml):
 #   wallpaper:
@@ -11,8 +13,11 @@ import argparse
 import ctypes
 import os
 import random
+import re
 import struct
 import winreg
+
+from PIL import ImageColor
 
 from core.configuration.user_conf import load_config
 
@@ -39,6 +44,23 @@ COLOR_PALETTE = {
     "white": "255 255 255",
     "gray": "128 128 128",
 }
+
+
+def resolve_color(name):
+    """Look up a color name's "R G B" registry value: first against the
+    standard palette, then falling back to CSS3/X11 color names (spaces,
+    dashes and underscores are stripped, so "light blue" matches
+    "lightblue"). Returns None if neither matches. """
+    normalized = name.strip().lower()
+    if normalized in COLOR_PALETTE:
+        return COLOR_PALETTE[normalized]
+
+    css_name = re.sub(r"[\s_-]", "", normalized)
+    try:
+        r, g, b = ImageColor.getrgb(css_name)
+    except ValueError:
+        return None
+    return f"{r} {g} {b}"
 
 
 def is_64_windows():
@@ -90,17 +112,24 @@ def set_random_picture_background(directory):
 def main(argv=None):
     parser = argparse.ArgumentParser(description="Set the desktop background")
     parser.add_argument(
-        "color", nargs="?",
-        help=f"solid color instead of a random picture, one of: {', '.join(sorted(COLOR_PALETTE))}",
+        "color", nargs="*",
+        help=(
+            "solid color instead of a random picture (e.g. 'green' or 'light blue'). "
+            f"Tries the standard palette first ({', '.join(sorted(COLOR_PALETTE))}); "
+            "if that doesn't match, falls back to CSS3/X11 color names."
+        ),
     )
     args = parser.parse_args(argv)
 
-    if args.color is not None:
-        color = args.color.lower()
-        rgb = COLOR_PALETTE.get(color)
+    if args.color:
+        color_input = " ".join(args.color)
+        rgb = resolve_color(color_input)
         if rgb is None:
-            parser.error(f"unknown color '{args.color}' - choose one of: {', '.join(sorted(COLOR_PALETTE))}")
-        print(color)
+            parser.error(
+                f"unknown color '{color_input}' - not in the standard palette "
+                f"({', '.join(sorted(COLOR_PALETTE))}) or a CSS3/X11 color name"
+            )
+        print(color_input.lower())
         set_solid_color_background(rgb)
         return
 

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -108,3 +108,25 @@ def test_unknown_color_exits_with_error(capsys):
 
     err = capsys.readouterr().err
     assert "unknown color" in err
+
+
+def test_resolve_color_prefers_the_standard_palette():
+    assert background.resolve_color("green") == "0 128 0"
+
+
+def test_resolve_color_falls_back_to_css3_x11_names():
+    assert background.resolve_color("light blue") == "173 216 230"
+    assert background.resolve_color("steelblue") == "70 130 180"
+
+
+def test_resolve_color_returns_none_for_unknown_name():
+    assert background.resolve_color("not-a-real-color") is None
+
+
+def test_multi_word_color_argument_resolves_via_css3_x11(fake_registry, monkeypatch, capsys):
+    monkeypatch.setattr(background, "get_sys_parameters_info", lambda: (lambda *args: 1))
+
+    background.main(["light", "blue"])
+
+    assert fake_registry == {"Background": "173 216 230"}
+    assert "light blue" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
Stacked on #33 (still open) - targets `background-color-command`, not `master`.

- `resolve_color()` now tries the standard 12-color palette first, then falls back to `PIL.ImageColor.getrgb()` (Pillow is already a dependency) for anything else, which implements the CSS3/X11 extended color keyword set (147 names).
- The `color` argument now accepts multiple words (`background light blue`), joined and normalized (spaces/dashes/underscores stripped) before the CSS3/X11 lookup, so `light blue` matches `lightblue`.
- `--help` now spells out the two-step lookup so it's discoverable without reading the source.
- Unknown names still print a clear error and exit non-zero.

## Test plan
- [x] `uv run pytest tests/test_background.py -q` (10 passed)
- [x] `uv run pytest tests/ -q` (66 passed)
- [x] `uv run background --help` and `uv run background notarealcolorxyz` manually
- [ ] Not run for real against the actual desktop background (mocked in tests only)